### PR TITLE
Fixed: View fields in IL mode

### DIFF
--- a/ICSharpCode.Decompiler/Disassembler/ReflectionDisassembler.cs
+++ b/ICSharpCode.Decompiler/Disassembler/ReflectionDisassembler.cs
@@ -709,7 +709,7 @@ namespace ICSharpCode.Decompiler.Disassembler
 			output.WriteDefinition(DisassemblerHelpers.Escape(field.Name), field);
 			if ((field.Attributes & FieldAttributes.HasFieldRVA) == FieldAttributes.HasFieldRVA) {
 				output.WriteKeyword(" at ");
-				output.Write("I_{0:x8}", field.RVA);
+				output.Write("I_{0:x8}", (uint)field.RVA);
 			}
 			if (field.HasConstant) {
 				output.Write(" = ");


### PR DESCRIPTION
Exception because RVA is an enum and enums are only allowed to have `x` format, not `x8`
